### PR TITLE
feat: improve sidebar design

### DIFF
--- a/Front-Novo/src/components/app-sidebar.tsx
+++ b/Front-Novo/src/components/app-sidebar.tsx
@@ -30,6 +30,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { LogoutButton } from "@/components/logout-button";
+import { SidebarToggle } from "@/components/sidebar-toggle";
 
 // Itens do menu principal
 const menuItems = [
@@ -75,23 +76,27 @@ export function AppSidebar() {
   const pathname = usePathname();
   const { data: session, status } = useSession();
   const { open } = useSidebar();
+  const userName = status === "loading" ? "Carregando..." : session?.user?.name || "Usuário";
+  const userEmail = status === "loading" ? "..." : session?.user?.email || "email@exemplo.com";
+  const userInitial = session?.user?.name?.charAt(0)?.toUpperCase() || "U";
 
   return (
     <TooltipProvider delayDuration={0}>
       <Sidebar collapsible="icon">
-        {/* Header com Logo e Nome */}
-        <SidebarHeader className="border-b">
+        {/* Header com Logo, Nome e Botão de Colapso */}
+        <SidebarHeader className="relative border-b bg-gradient-primary text-white">
           <div className="flex items-center gap-3 px-3 py-4">
-            <div className="h-10 w-10 rounded-lg bg-primary flex items-center justify-center text-primary-foreground font-bold shrink-0">
+            <div className="h-10 w-10 rounded-lg bg-white/20 flex items-center justify-center font-bold shrink-0">
               K
             </div>
             {open && (
               <div className="flex flex-col overflow-hidden">
                 <span className="text-lg font-bold">KOMVOS</span>
-                <span className="text-sm text-muted-foreground">MIND</span>
+                <span className="text-sm opacity-80">MIND</span>
               </div>
             )}
           </div>
+          <SidebarToggle className="absolute -right-3 top-2 text-white hover:bg-white/10" />
         </SidebarHeader>
 
         {/* Conteúdo Principal - Menu de Navegação */}
@@ -155,49 +160,47 @@ export function AppSidebar() {
         </SidebarContent>
 
         {/* Footer com Informações do Usuário */}
-        <SidebarFooter className="border-t">
-          <div className={`${open ? 'p-4' : 'p-2'}`}>
+        <SidebarFooter className="border-t bg-gradient-primary text-white">
+          <div className={open ? "p-4" : "p-2"}>
             {open ? (
-              <>
-                {/* Informações do usuário - visível quando expandido */}
-                <div className="flex flex-col gap-2 mb-3">
-                  <span className="text-sm font-medium truncate">
-                    {status === "loading" ? "Carregando..." : session?.user?.name || "Usuário"}
-                  </span>
-                  <span className="text-xs text-muted-foreground truncate">
-                    {status === "loading" ? "..." : session?.user?.email || "email@exemplo.com"}
-                  </span>
+              <div className="flex items-center gap-3">
+                <div className="h-8 w-8 rounded-full bg-white/20 flex items-center justify-center text-sm font-medium">
+                  {userInitial}
                 </div>
-                
-                {/* Botão de Logout com texto */}
-                <LogoutButton 
-                  showText={true}
+                <div className="flex flex-col overflow-hidden">
+                  <span className="text-sm font-medium truncate">{userName}</span>
+                  <span className="text-xs opacity-80 truncate">{userEmail}</span>
+                </div>
+                <LogoutButton
+                  showText={false}
                   variant="ghost"
-                  size="sm"
-                  className="w-full"
+                  size="icon"
+                  className="ml-auto h-8 w-8 text-white hover:bg-white/10"
                 />
-              </>
+              </div>
             ) : (
-              /* Quando colapsado, mostra apenas o botão de logout com tooltip */
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div className="flex justify-center">
-                    <LogoutButton 
+              <div className="flex flex-col items-center gap-2">
+                <div className="h-8 w-8 rounded-full bg-white/20 flex items-center justify-center text-sm font-medium">
+                  {userInitial}
+                </div>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <LogoutButton
                       showText={false}
                       variant="ghost"
                       size="icon"
-                      className="h-10 w-10"
+                      className="h-8 w-8 text-white hover:bg-white/10"
                     />
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent side="right">
-                  <div className="text-xs">
-                    <div className="font-medium">{session?.user?.name || "Usuário"}</div>
-                    <div className="text-muted-foreground">{session?.user?.email || "email@exemplo.com"}</div>
-                    <div className="mt-1 text-destructive">Clique para sair</div>
-                  </div>
-                </TooltipContent>
-              </Tooltip>
+                  </TooltipTrigger>
+                  <TooltipContent side="right">
+                    <div className="text-xs">
+                      <div className="font-medium">{userName}</div>
+                      <div className="text-muted-foreground">{userEmail}</div>
+                      <div className="mt-1 text-destructive">Clique para sair</div>
+                    </div>
+                  </TooltipContent>
+                </Tooltip>
+              </div>
             )}
           </div>
         </SidebarFooter>

--- a/Front-Novo/src/components/sidebar-toggle.tsx
+++ b/Front-Novo/src/components/sidebar-toggle.tsx
@@ -5,17 +5,17 @@ import { Button } from "@/components/ui/button";
 import { useSidebar } from "@/components/ui/sidebar";
 import { cn } from "@/lib/utils";
 
-export function SidebarToggle() {
+export function SidebarToggle({ className }: { className?: string }) {
   const { open, toggleSidebar } = useSidebar();
 
   return (
     <Button
       variant="ghost"
       size="icon"
-      className="h-9 w-9"
+      className={cn("h-9 w-9", className)}
       onClick={toggleSidebar}
     >
-      <ChevronLeft 
+      <ChevronLeft
         className={cn(
           "h-4 w-4 transition-transform duration-200",
           !open && "rotate-180"

--- a/Front-Novo/src/styles/globals.css
+++ b/Front-Novo/src/styles/globals.css
@@ -6,10 +6,13 @@
 @theme {
 
   --color-background: #f0f9ff;
-  --color-foreground: #0c4a6e;
+  --color-foreground: #007AA5;
+
+  --color-primary: #007AA5;
+  --color-primary-foreground: #ffffff;
 
   --color-card: #ffffff;
-  --color-card-foreground: #0c4a6e;
+  --color-card-foreground: #007AA5;
 
   --color-muted: #64748b;
   --color-accent: #00AFEF;
@@ -18,6 +21,8 @@
   --color-danger: #ef4444;
   --color-warning: #f59e0b;
   --color-success: #10b981;
+
+  --gradient-primary: linear-gradient(135deg, #00AFEF, #007AA5);
 
   --radius: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- add arrow toggle to sidebar header and show icons when collapsed
- enhance sidebar footer with user avatar and gradient styling
- define primary/gradient colors based on #00AFEF and #007AA5

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c02844977c832996dd611d9f74d08e